### PR TITLE
Implement Rolling Average to Smooth Throttling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,10 @@ uint32_t lastLedFlash = 0;
 
 bool ledFlash = false;
 
+uint16_t outputSamples[20] = {0};
+int sampleIndex = 0;
+uint32_t rollingSum = 0;
+
 // This struct contains all the components of a CAN message. dataLength must be <= 8, 
 // and the first [dataLength] positions of data[] must contain valid data
 typedef uint8_t CanBuffer[8];
@@ -165,7 +169,20 @@ void loop() {
 
     // If the new output is different than the old output, update the voltage on the DAC
     if(newOutput != currentOutput) {
-        currentOutput = newOutput;
+
+        if (SMOOTH_THROTTLE) {
+            rollingSum -= outputSamples[sampleIndex];
+            rollingSum += newOutput;
+            outputSamples[sampleIndex] = newOutput;
+            sampleIndex = (sampleIndex + 1) % 20;
+
+            // Calculate the rolling average
+            uint16_t rollingAverage = rollingSum / 20;
+            currentOutput = rollingAverage;
+        } else {
+            currentOutput = newOutput;
+        }
+        
         dac.setVoltage(currentOutput, false); 
         DEBUG_SERIAL_LN("Voltage set to: " + String(currentOutput / DAC_VALUE_TO_V) + "v");
     }

--- a/src/settings.h
+++ b/src/settings.h
@@ -23,6 +23,9 @@
 // Turn on to print received CAN messages to serial monitor
 #define CAN_DEBUG_RECEIVE       0
 
+// Turn on to implement a rolling average on throttle input, mitigating spikes and noise
+#define SMOOTH_THROTTLE         1
+
 // Turn on to scale exponentially
 #define SCALE_EXP               0
 // Scaling factors


### PR DESCRIPTION
When testing the motor controller in the car, we observed severe jolts in the drive which were only detected when using CAN to throttle. As a software solution, I added a rolling average on the last 20 data points, which would smooth any spikes before reaching the motor.

As of now, this change successfully smooths the drive with no recognizable repercussions. The vehicle slowdown is still quick enough to have a negligible effect on braking distance.